### PR TITLE
Add new-game modal command

### DIFF
--- a/commands/game/new-game.js
+++ b/commands/game/new-game.js
@@ -1,0 +1,42 @@
+const { SlashCommandBuilder, ModalBuilder, TextInputBuilder, TextInputStyle, ActionRowBuilder } = require('discord.js');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('new-game')
+        .setDescription('Erstellt eine neue Spielankuendigung.'),
+    async execute(interaction) {
+        const now = new Date();
+        const defaultDate = now.toISOString().slice(0, 16);
+
+        const modal = new ModalBuilder()
+            .setCustomId('newGameModal')
+            .setTitle('Neues Spiel');
+
+        const dateInput = new TextInputBuilder()
+            .setCustomId('gameDate')
+            .setLabel('Datum/Uhrzeit (YYYY-MM-DDTHH:mm)')
+            .setStyle(TextInputStyle.Short)
+            .setRequired(true)
+            .setValue(defaultDate);
+
+        const tierInput = new TextInputBuilder()
+            .setCustomId('gameTier')
+            .setLabel('Tier (BT, LT, HT, ET, Alle)')
+            .setStyle(TextInputStyle.Short)
+            .setRequired(true);
+
+        const textInput = new TextInputBuilder()
+            .setCustomId('gameText')
+            .setLabel('Text')
+            .setStyle(TextInputStyle.Paragraph)
+            .setRequired(false);
+
+        modal.addComponents(
+            new ActionRowBuilder().addComponents(dateInput),
+            new ActionRowBuilder().addComponents(tierInput),
+            new ActionRowBuilder().addComponents(textInput),
+        );
+
+        await interaction.showModal(modal);
+    },
+};

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -3,6 +3,23 @@ const { Events, MessageFlags } = require('discord.js');
 module.exports = {
     name: Events.InteractionCreate,
     async execute(interaction) {
+        if (interaction.isModalSubmit() && interaction.customId === 'newGameModal') {
+            const tier = interaction.fields.getTextInputValue('gameTier');
+            const dateString = interaction.fields.getTextInputValue('gameDate');
+            const text = interaction.fields.getTextInputValue('gameText') || '';
+
+            let time = Date.parse(dateString);
+            if (Number.isNaN(time)) {
+                time = Date.now();
+            }
+
+            const role = interaction.guild.roles.cache.find(r => r.name.toLowerCase() === 'magiergilde');
+            const mention = role ? `<@&${role.id}>` : '@magiergilde';
+
+            await interaction.reply(`${tier} - <t:${Math.floor(time / 1000)}:f> - ${text} - ${mention}`);
+            return;
+        }
+
         if (!interaction.isChatInputCommand()) return;
 
         const command = interaction.client.commands.get(interaction.commandName);


### PR DESCRIPTION
## Summary
- implement `/new-game` command that opens a modal asking for date/time, tier, and custom text
- process modal submission to send formatted announcement mentioning the `magiergilde` role

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68745a3cc0cc8322bbc5a7b7757d8c6f