### PR TITLE
Implement select-based new-game command

### DIFF
--- a/commands/game/new-game.js
+++ b/commands/game/new-game.js
@@ -1,42 +1,48 @@
-const { SlashCommandBuilder, ModalBuilder, TextInputBuilder, TextInputStyle, ActionRowBuilder } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
     data: new SlashCommandBuilder()
         .setName('new-game')
-        .setDescription('Erstellt eine neue Spielankuendigung.'),
+        .setDescription('Erstellt eine neue Spielankuendigung.')
+        .addStringOption(option =>
+            option
+                .setName('date')
+                .setDescription('Datum/Uhrzeit (YYYY-MM-DDTHH:mm)')
+                .setRequired(false))
+        .addStringOption(option =>
+            option
+                .setName('tier')
+                .setDescription('Tier')
+                .setRequired(true)
+                .addChoices(
+                    { name: 'BT', value: 'BT' },
+                    { name: 'LT', value: 'LT' },
+                    { name: 'HT', value: 'HT' },
+                    { name: 'ET', value: 'ET' },
+                    { name: 'Alle', value: 'Alle' },
+                ))
+        .addStringOption(option =>
+            option
+                .setName('text')
+                .setDescription('Text')
+                .setRequired(false)),
     async execute(interaction) {
+        const tier = interaction.options.getString('tier');
+        const dateString = interaction.options.getString('date');
+        const text = interaction.options.getString('text') || '';
+
         const now = new Date();
         const defaultDate = now.toISOString().slice(0, 16);
+        const date = dateString || defaultDate;
 
-        const modal = new ModalBuilder()
-            .setCustomId('newGameModal')
-            .setTitle('Neues Spiel');
+        let time = Date.parse(date);
+        if (Number.isNaN(time)) {
+            time = Date.now();
+        }
 
-        const dateInput = new TextInputBuilder()
-            .setCustomId('gameDate')
-            .setLabel('Datum/Uhrzeit (YYYY-MM-DDTHH:mm)')
-            .setStyle(TextInputStyle.Short)
-            .setRequired(true)
-            .setValue(defaultDate);
+        const role = interaction.guild.roles.cache.find(r => r.name.toLowerCase() === 'magiergilde');
+        const mention = role ? `<@&${role.id}>` : '@magiergilde';
 
-        const tierInput = new TextInputBuilder()
-            .setCustomId('gameTier')
-            .setLabel('Tier (BT, LT, HT, ET, Alle)')
-            .setStyle(TextInputStyle.Short)
-            .setRequired(true);
-
-        const textInput = new TextInputBuilder()
-            .setCustomId('gameText')
-            .setLabel('Text')
-            .setStyle(TextInputStyle.Paragraph)
-            .setRequired(false);
-
-        modal.addComponents(
-            new ActionRowBuilder().addComponents(dateInput),
-            new ActionRowBuilder().addComponents(tierInput),
-            new ActionRowBuilder().addComponents(textInput),
-        );
-
-        await interaction.showModal(modal);
+        await interaction.reply(`${tier} - <t:${Math.floor(time / 1000)}:f> - ${text} - ${mention}`);
     },
 };

--- a/commands/game/new-game.js
+++ b/commands/game/new-game.js
@@ -1,4 +1,9 @@
-const { SlashCommandBuilder, ActionRowBuilder, StringSelectMenuBuilder } = require('discord.js');
+const {
+    SlashCommandBuilder,
+    ActionRowBuilder,
+    StringSelectMenuBuilder,
+    MessageFlags,
+} = require('discord.js');
 const { pendingGames } = require('../../state');
 
 module.exports = {
@@ -48,6 +53,10 @@ module.exports = {
                 ),
         );
 
-        await interaction.reply({ content: 'W\xC3\xA4hle das Tier', components: [row], ephemeral: true });
+        await interaction.reply({
+            content: 'W\xC3\xA4hle das Tier',
+            components: [row],
+            flags: MessageFlags.Ephemeral,
+        });
     },
 };

--- a/commands/game/new-game.js
+++ b/commands/game/new-game.js
@@ -10,35 +10,10 @@ const { pendingGames } = require('../../state');
 module.exports = {
     data: new SlashCommandBuilder()
         .setName('new-game')
-        .setDescription('Erstellt eine neue Spielankuendigung.')
-        .addStringOption(option =>
-            option
-                .setName('date')
-                .setDescription('Datum/Uhrzeit (YYYY-MM-DDTHH:mm)')
-                .setRequired(true))
-        .addStringOption(option =>
-            option
-                .setName('text')
-                .setDescription('Text')
-                .setRequired(true)),
+        .setDescription('Erstellt eine neue Spielankuendigung.'),
     async execute(interaction) {
-        const dateString = interaction.options.getString('date');
-        const text = interaction.options.getString('text') || '';
-
-        const now = new Date();
-        const defaultDate = now.toISOString().slice(0, 16);
-        const date = dateString || defaultDate;
-
-        let time = Date.parse(date);
-        if (Number.isNaN(time)) {
-            time = Date.now();
-        }
-
-        const role = interaction.guild.roles.cache.find(r => r.name.toLowerCase() === 'magiergilde');
-        const mention = role ? `<@&${role.id}>` : '@magiergilde';
-
         const id = interaction.id;
-        pendingGames.set(id, { time, text, mention, tiers: new Set() });
+        pendingGames.set(id, { userId: interaction.user.id, tiers: new Set() });
 
         const tierButtons = ['BT', 'LT', 'HT', 'ET'].map(tier =>
             new ButtonBuilder()
@@ -50,13 +25,13 @@ module.exports = {
         const row1 = new ActionRowBuilder().addComponents(tierButtons);
         const row2 = new ActionRowBuilder().addComponents(
             new ButtonBuilder()
-                .setCustomId(`confirm_${id}`)
-                .setLabel('Ank\xC3\xBCndigen')
+                .setCustomId(`details_${id}`)
+                .setLabel('Weiter')
                 .setStyle(ButtonStyle.Primary),
         );
 
         await interaction.reply({
-            content: 'Tiers ausw\xC3\xA4hlen und anschlie\xC3\x9Fend "Ank\xC3\xBCndigen" klicken:',
+            content: 'Tiers ausw\xC3\xA4hlen und dann "Weiter" klicken:',
             components: [row1, row2],
             flags: MessageFlags.Ephemeral,
         });

--- a/commands/game/new-game.js
+++ b/commands/game/new-game.js
@@ -44,10 +44,10 @@ module.exports = {
         const mention = role ? `<@&${role.id}>` : '@magiergilde';
 
         const emojiMap = {
-            BT: ':MG_BT:',
-            LT: ':MG_LT:',
-            HT: ':MG_HT:',
-            ET: ':MG_ET:',
+            BT: '<:MG_BT:804713705358622800>',
+            LT: '<:MG_LT:804713705262546995>',
+            HT: '<:MG_HT:804713704918089780>',
+            ET: '<:MG_ET:804713705337782312>',
         };
         const tierDisplay = emojiMap[tier] || tier;
 

--- a/commands/game/new-game.js
+++ b/commands/game/new-game.js
@@ -8,7 +8,7 @@ module.exports = {
             option
                 .setName('date')
                 .setDescription('Datum/Uhrzeit (YYYY-MM-DDTHH:mm)')
-                .setRequired(false))
+                .setRequired(true))
         .addStringOption(option =>
             option
                 .setName('tier')
@@ -25,7 +25,7 @@ module.exports = {
             option
                 .setName('text')
                 .setDescription('Text')
-                .setRequired(false)),
+                .setRequired(true)),
     async execute(interaction) {
         const tier = interaction.options.getString('tier');
         const dateString = interaction.options.getString('date');

--- a/commands/game/new-game.js
+++ b/commands/game/new-game.js
@@ -15,10 +15,10 @@ module.exports = {
                 .setDescription('Tier')
                 .setRequired(true)
                 .addChoices(
-                    { name: 'BT', value: 'BT' },
-                    { name: 'LT', value: 'LT' },
-                    { name: 'HT', value: 'HT' },
-                    { name: 'ET', value: 'ET' },
+                    { name: 'Beginner Tier', value: 'BT' },
+                    { name: 'Low Tier', value: 'LT' },
+                    { name: 'High Tier', value: 'HT' },
+                    { name: 'Elite Tier', value: 'ET' },
                     { name: 'Alle', value: 'Alle' },
                 ))
         .addStringOption(option =>
@@ -43,6 +43,14 @@ module.exports = {
         const role = interaction.guild.roles.cache.find(r => r.name.toLowerCase() === 'magiergilde');
         const mention = role ? `<@&${role.id}>` : '@magiergilde';
 
-        await interaction.reply(`${tier} - <t:${Math.floor(time / 1000)}:f> - ${text} - ${mention}`);
+        const emojiMap = {
+            BT: ':MG_BT:',
+            LT: ':MG_LT:',
+            HT: ':MG_HT:',
+            ET: ':MG_ET:',
+        };
+        const tierDisplay = emojiMap[tier] || tier;
+
+        await interaction.reply(`${tierDisplay} - <t:${Math.floor(time / 1000)}:f> - ${text} - ${mention}`);
     },
 };

--- a/commands/game/new-game.js
+++ b/commands/game/new-game.js
@@ -1,7 +1,8 @@
 const {
     SlashCommandBuilder,
     ActionRowBuilder,
-    StringSelectMenuBuilder,
+    ButtonBuilder,
+    ButtonStyle,
     MessageFlags,
 } = require('discord.js');
 const { pendingGames } = require('../../state');
@@ -36,26 +37,27 @@ module.exports = {
         const role = interaction.guild.roles.cache.find(r => r.name.toLowerCase() === 'magiergilde');
         const mention = role ? `<@&${role.id}>` : '@magiergilde';
 
-        const selectId = `tierSelect_${interaction.id}`;
-        pendingGames.set(selectId, { time, text, mention });
+        const id = interaction.id;
+        pendingGames.set(id, { time, text, mention, tiers: new Set() });
 
-        const row = new ActionRowBuilder().addComponents(
-            new StringSelectMenuBuilder()
-                .setCustomId(selectId)
-                .setPlaceholder('Tier ausw\xC3\xA4hlen')
-                .setMinValues(1)
-                .setMaxValues(4)
-                .addOptions(
-                    { label: 'Beginner Tier', value: 'BT' },
-                    { label: 'Low Tier', value: 'LT' },
-                    { label: 'High Tier', value: 'HT' },
-                    { label: 'Elite Tier', value: 'ET' },
-                ),
+        const tierButtons = ['BT', 'LT', 'HT', 'ET'].map(tier =>
+            new ButtonBuilder()
+                .setCustomId(`tier_${id}_${tier}`)
+                .setLabel(tier)
+                .setStyle(ButtonStyle.Secondary),
+        );
+
+        const row1 = new ActionRowBuilder().addComponents(tierButtons);
+        const row2 = new ActionRowBuilder().addComponents(
+            new ButtonBuilder()
+                .setCustomId(`confirm_${id}`)
+                .setLabel('Ank\xC3\xBCndigen')
+                .setStyle(ButtonStyle.Primary),
         );
 
         await interaction.reply({
-            content: 'W\xC3\xA4hle das Tier',
-            components: [row],
+            content: 'Tiers ausw\xC3\xA4hlen und anschlie\xC3\x9Fend "Ank\xC3\xBCndigen" klicken:',
+            components: [row1, row2],
             flags: MessageFlags.Ephemeral,
         });
     },

--- a/commands/game/new-game.js
+++ b/commands/game/new-game.js
@@ -13,7 +13,11 @@ module.exports = {
         .setDescription('Erstellt eine neue Spielankuendigung.'),
     async execute(interaction) {
         const id = interaction.id;
-        pendingGames.set(id, { userId: interaction.user.id, tiers: new Set() });
+        pendingGames.set(id, {
+            userId: interaction.user.id,
+            tiers: new Set(),
+            commandInteraction: interaction,
+        });
 
         const tierButtons = ['BT', 'LT', 'HT', 'ET'].map(tier =>
             new ButtonBuilder()

--- a/commands/game/new-game.js
+++ b/commands/game/new-game.js
@@ -1,4 +1,5 @@
-const { SlashCommandBuilder } = require('discord.js');
+const { SlashCommandBuilder, ActionRowBuilder, StringSelectMenuBuilder } = require('discord.js');
+const { pendingGames } = require('../../state');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -11,23 +12,10 @@ module.exports = {
                 .setRequired(true))
         .addStringOption(option =>
             option
-                .setName('tier')
-                .setDescription('Tier')
-                .setRequired(true)
-                .addChoices(
-                    { name: 'Beginner Tier', value: 'BT' },
-                    { name: 'Low Tier', value: 'LT' },
-                    { name: 'High Tier', value: 'HT' },
-                    { name: 'Elite Tier', value: 'ET' },
-                    { name: 'Alle', value: 'Alle' },
-                ))
-        .addStringOption(option =>
-            option
                 .setName('text')
                 .setDescription('Text')
                 .setRequired(true)),
     async execute(interaction) {
-        const tier = interaction.options.getString('tier');
         const dateString = interaction.options.getString('date');
         const text = interaction.options.getString('text') || '';
 
@@ -43,17 +31,23 @@ module.exports = {
         const role = interaction.guild.roles.cache.find(r => r.name.toLowerCase() === 'magiergilde');
         const mention = role ? `<@&${role.id}>` : '@magiergilde';
 
-        const emojiMap = {
-            BT: '804713705358622800',
-            LT: '804713705262546995',
-            HT: '804713704918089780',
-            ET: '804713705337782312',
-        };
+        const selectId = `tierSelect_${interaction.id}`;
+        pendingGames.set(selectId, { time, text, mention });
 
-        const emojiId = emojiMap[tier];
-        const emoji = emojiId ? interaction.client.emojis.cache.get(emojiId) : null;
-        const tierDisplay = emoji ? emoji.toString() : tier;
+        const row = new ActionRowBuilder().addComponents(
+            new StringSelectMenuBuilder()
+                .setCustomId(selectId)
+                .setPlaceholder('Tier ausw\xC3\xA4hlen')
+                .setMinValues(1)
+                .setMaxValues(4)
+                .addOptions(
+                    { label: 'Beginner Tier', value: 'BT' },
+                    { label: 'Low Tier', value: 'LT' },
+                    { label: 'High Tier', value: 'HT' },
+                    { label: 'Elite Tier', value: 'ET' },
+                ),
+        );
 
-        await interaction.reply(`${tierDisplay} - <t:${Math.floor(time / 1000)}:f> - ${text} - ${mention}`);
+        await interaction.reply({ content: 'W\xC3\xA4hle das Tier', components: [row], ephemeral: true });
     },
 };

--- a/commands/game/new-game.js
+++ b/commands/game/new-game.js
@@ -44,12 +44,15 @@ module.exports = {
         const mention = role ? `<@&${role.id}>` : '@magiergilde';
 
         const emojiMap = {
-            BT: '<:MG_BT:804713705358622800>',
-            LT: '<:MG_LT:804713705262546995>',
-            HT: '<:MG_HT:804713704918089780>',
-            ET: '<:MG_ET:804713705337782312>',
+            BT: '804713705358622800',
+            LT: '804713705262546995',
+            HT: '804713704918089780',
+            ET: '804713705337782312',
         };
-        const tierDisplay = emojiMap[tier] || tier;
+
+        const emojiId = emojiMap[tier];
+        const emoji = emojiId ? interaction.client.emojis.cache.get(emojiId) : null;
+        const tierDisplay = emoji ? emoji.toString() : tier;
 
         await interaction.reply(`${tierDisplay} - <t:${Math.floor(time / 1000)}:f> - ${text} - ${mention}`);
     },

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -1,8 +1,36 @@
 const { Events, MessageFlags } = require('discord.js');
+const { pendingGames } = require('../state');
 
 module.exports = {
     name: Events.InteractionCreate,
     async execute(interaction) {
+        if (interaction.isStringSelectMenu() && interaction.customId.startsWith('tierSelect_')) {
+            const data = pendingGames.get(interaction.customId);
+            pendingGames.delete(interaction.customId);
+
+            if (!data) {
+                await interaction.reply({ content: 'Keine Daten gefunden.', ephemeral: true });
+                return;
+            }
+
+            const emojiMap = {
+                BT: '804713705358622800',
+                LT: '804713705262546995',
+                HT: '804713704918089780',
+                ET: '804713705337782312',
+            };
+
+            const tiers = interaction.values.map(t => {
+                const id = emojiMap[t];
+                const e = id ? interaction.client.emojis.cache.get(id) : null;
+                return e ? e.toString() : t;
+            }).join(' ');
+
+            await interaction.channel.send(`${tiers} - <t:${Math.floor(data.time / 1000)}:f> - ${data.text} - ${data.mention}`);
+            await interaction.update({ content: 'Ank\xC3\xBCndigung erstellt', components: [] });
+            return;
+        }
+
         if (!interaction.isChatInputCommand()) return;
 
         const command = interaction.client.commands.get(interaction.commandName);

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -64,7 +64,11 @@ module.exports = {
             }
 
             const now = new Date();
-            const defaultDate = now.toISOString().slice(0, 16);
+            const defaultDate = now.toISOString().slice(0, 10);
+            const nextHour = new Date(now);
+            nextHour.setMinutes(0, 0, 0);
+            nextHour.setHours(nextHour.getHours() + 1);
+            const defaultTime = nextHour.toISOString().slice(11, 16);
 
             const modal = new ModalBuilder()
                 .setCustomId(`detailsModal_${id}`)
@@ -72,10 +76,17 @@ module.exports = {
 
             const dateInput = new TextInputBuilder()
                 .setCustomId('gameDate')
-                .setLabel('Datum/Uhrzeit (YYYY-MM-DDTHH:mm)')
+                .setLabel('Datum (YYYY-MM-DD)')
                 .setStyle(TextInputStyle.Short)
                 .setRequired(true)
                 .setValue(defaultDate);
+
+            const timeInput = new TextInputBuilder()
+                .setCustomId('gameTime')
+                .setLabel('Uhrzeit (HH:mm)')
+                .setStyle(TextInputStyle.Short)
+                .setRequired(true)
+                .setValue(defaultTime);
 
             const textInput = new TextInputBuilder()
                 .setCustomId('gameText')
@@ -85,6 +96,7 @@ module.exports = {
 
             modal.addComponents(
                 new ActionRowBuilder().addComponents(dateInput),
+                new ActionRowBuilder().addComponents(timeInput),
                 new ActionRowBuilder().addComponents(textInput),
             );
 
@@ -105,10 +117,11 @@ module.exports = {
             }
 
             const dateString = interaction.fields.getTextInputValue('gameDate');
+            const timeString = interaction.fields.getTextInputValue('gameTime');
             const text = interaction.fields.getTextInputValue('gameText') || '';
             pendingGames.delete(id);
 
-            let time = Date.parse(dateString);
+            let time = Date.parse(`${dateString}T${timeString}`);
             if (Number.isNaN(time)) {
                 time = Date.now();
             }

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -129,8 +129,27 @@ module.exports = {
                 return e ? e.toString() : t;
             }).join(' ');
 
-            await interaction.channel.send(`${tiers} - <t:${Math.floor(time / 1000)}:f> - ${mention} - ${text}\nErstellt von <@${data.userId}>`);
+            const date = new Date(time);
+            const formattedDate = `${date.toLocaleString('de-DE', {
+                day: '2-digit',
+            })}. ${date.toLocaleString('de-DE', { month: 'long' })} ${date.toLocaleString('de-DE', {
+                year: 'numeric',
+            })} ${date.toLocaleString('de-DE', {
+                hour: '2-digit',
+                minute: '2-digit',
+                hour12: false,
+            })}`;
+
+            const announcement = `${tiers} - ${formattedDate} - von <@${data.userId}> - ${mention} - ${text}`;
+            const msg = await interaction.channel.send(announcement);
+            await msg.startThread({ name: 'Spiel-Thread', autoArchiveDuration: 1440 });
+
+            if (data.commandInteraction) {
+                await data.commandInteraction.deleteReply().catch(() => {});
+            }
+
             await interaction.reply({ content: 'Ankündigung erstellt', flags: MessageFlags.Ephemeral });
+            setTimeout(() => interaction.deleteReply().catch(() => {}), 5000);
             return;
         }
 

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -4,6 +4,9 @@ const {
     ActionRowBuilder,
     ButtonBuilder,
     ButtonStyle,
+    ModalBuilder,
+    TextInputBuilder,
+    TextInputStyle,
 } = require('discord.js');
 const { pendingGames } = require('../state');
 
@@ -63,33 +66,46 @@ module.exports = {
             const now = new Date();
             const defaultDate = now.toISOString().slice(0, 16);
 
-            await interaction.update({
-                content: `Bitte Datum/Uhrzeit eingeben (YYYY-MM-DDTHH:mm). Standard: ${defaultDate}`,
-                components: [],
-            });
+            const modal = new ModalBuilder()
+                .setCustomId(`detailsModal_${id}`)
+                .setTitle('Spieldetails');
 
-            const filter = m => m.author.id === data.userId;
+            const dateInput = new TextInputBuilder()
+                .setCustomId('gameDate')
+                .setLabel('Datum/Uhrzeit (YYYY-MM-DDTHH:mm)')
+                .setStyle(TextInputStyle.Short)
+                .setRequired(true)
+                .setValue(defaultDate);
 
-            const dateCollected = await interaction.channel.awaitMessages({ filter, max: 1, time: 60000 });
-            if (!dateCollected.size) {
-                pendingGames.delete(id);
-                await interaction.followUp({ content: 'Zeit abgelaufen. Bitte Befehl erneut ausf\u00fchren.', flags: MessageFlags.Ephemeral });
+            const textInput = new TextInputBuilder()
+                .setCustomId('gameText')
+                .setLabel('Text')
+                .setStyle(TextInputStyle.Paragraph)
+                .setRequired(false);
+
+            modal.addComponents(
+                new ActionRowBuilder().addComponents(dateInput),
+                new ActionRowBuilder().addComponents(textInput),
+            );
+
+            await interaction.showModal(modal);
+            return;
+        }
+
+        if (interaction.isModalSubmit() && interaction.customId.startsWith('detailsModal_')) {
+            const id = interaction.customId.replace('detailsModal_', '');
+            const data = pendingGames.get(id);
+
+            if (!data) {
+                await interaction.reply({
+                    content: 'Keine Daten gefunden.',
+                    flags: MessageFlags.Ephemeral,
+                });
                 return;
             }
-            const dateMsg = dateCollected.first();
-            const dateString = dateMsg.content.trim() || defaultDate;
-            await dateMsg.delete().catch(() => {});
 
-            await interaction.followUp({ content: 'Bitte Text eingeben (optional):', flags: MessageFlags.Ephemeral });
-            const textCollected = await interaction.channel.awaitMessages({ filter, max: 1, time: 60000 });
-            if (!textCollected.size) {
-                pendingGames.delete(id);
-                await interaction.followUp({ content: 'Zeit abgelaufen. Bitte Befehl erneut ausf\u00fchren.', flags: MessageFlags.Ephemeral });
-                return;
-            }
-            const textMsg = textCollected.first();
-            const text = textMsg.content.trim();
-            await textMsg.delete().catch(() => {});
+            const dateString = interaction.fields.getTextInputValue('gameDate');
+            const text = interaction.fields.getTextInputValue('gameText') || '';
             pendingGames.delete(id);
 
             let time = Date.parse(dateString);
@@ -114,7 +130,7 @@ module.exports = {
             }).join(' ');
 
             await interaction.channel.send(`${tiers} - <t:${Math.floor(time / 1000)}:f> - ${mention} - ${text}\nErstellt von <@${data.userId}>`);
-            await interaction.followUp({ content: 'Ank\u00fcndigung erstellt', flags: MessageFlags.Ephemeral });
+            await interaction.reply({ content: 'Ankündigung erstellt', flags: MessageFlags.Ephemeral });
             return;
         }
 

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -3,23 +3,6 @@ const { Events, MessageFlags } = require('discord.js');
 module.exports = {
     name: Events.InteractionCreate,
     async execute(interaction) {
-        if (interaction.isModalSubmit() && interaction.customId === 'newGameModal') {
-            const tier = interaction.fields.getTextInputValue('gameTier');
-            const dateString = interaction.fields.getTextInputValue('gameDate');
-            const text = interaction.fields.getTextInputValue('gameText') || '';
-
-            let time = Date.parse(dateString);
-            if (Number.isNaN(time)) {
-                time = Date.now();
-            }
-
-            const role = interaction.guild.roles.cache.find(r => r.name.toLowerCase() === 'magiergilde');
-            const mention = role ? `<@&${role.id}>` : '@magiergilde';
-
-            await interaction.reply(`${tier} - <t:${Math.floor(time / 1000)}:f> - ${text} - ${mention}`);
-            return;
-        }
-
         if (!interaction.isChatInputCommand()) return;
 
         const command = interaction.client.commands.get(interaction.commandName);

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -9,7 +9,10 @@ module.exports = {
             pendingGames.delete(interaction.customId);
 
             if (!data) {
-                await interaction.reply({ content: 'Keine Daten gefunden.', ephemeral: true });
+                await interaction.reply({
+                    content: 'Keine Daten gefunden.',
+                    flags: MessageFlags.Ephemeral,
+                });
                 return;
             }
 

--- a/state.js
+++ b/state.js
@@ -1,0 +1,3 @@
+module.exports = {
+    pendingGames: new Map(),
+};


### PR DESCRIPTION
## Summary
- refactor `/new-game` to avoid modal usage
- specify `tier` via slash command choices
- simplify interactionCreate handling

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68745f9d0bac8322af4f64822a6cba24